### PR TITLE
dark/light mode icon bug fix

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,10 @@
       type="image/x-icon"
     />
    
+    <link
+       rel="stylesheet"
+       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+     />
 
     {% block head %}{% endblock %}
   </head>


### PR DESCRIPTION
- fixed google icon bug, head data in base.html for google icons seemed to have been deleted by mistake